### PR TITLE
Fix ooshop auto-appro

### DIFF
--- a/app/components/admin/food/autoappro/ooshop.html
+++ b/app/components/admin/food/autoappro/ooshop.html
@@ -1,64 +1,14 @@
 <div class="col-sm-12 col-md-12 col-lg-12">
     <h3>Auto-Appro : Ooshop</h3>
-    <div class="row" ng-show="stape == 1">
-        <div class="col-md-2 text-right h3">
-            Étape 1<br />
-            <small>Connexion</small>
-        </div>
-        <div class="col-md-10">
-            <form class="form-horizontal" ng-submit="stape1.validate(stape1.login, stape1.password)">
-                <div class="form-group">
-                    <label class="col-md-4 col-lg-2 control-label">Adresse email</label>
-                    <div class="col-md-8 col-lg-10">
-                        <input type="email" class="form-control" placeholder="louis.vaneau@polytechnique.edu" ng-model="stape1.login" />
-                    </div>
+    <div class="col-md-10">
+        <form class="form-horizontal" ng-submit="validate(input)">
+            <div class="form-group">
+                <label class="col-md-4 col-lg-2 control-label">Copiez votre facture Ooshop ici</label>
+                <div class="col-md-8 col-lg-10">
+                    <textarea name="Facture" class="form-control" ng-model="input" />
                 </div>
-                <div class="form-group">
-                    <label class="col-md-4 col-lg-2 control-label">Mot de passe</label>
-                    <div class="col-md-8 col-lg-10">
-                        <input type="password" class="form-control" placeholder="****" ng-model="stape1.password" />
-                    </div>
-                </div>
-                <div class="form-group">
-                    <div class="col-md-offset-4 col-md-8 col-lg-10 col-lg-offset-2">
-                        <button type="submit" class="btn btn-success" ng-class="stape1.loading && 'disabled' || ''">
-                            Connexion à Ooshop <span class="glyphicon-refresh-animate glyphicon glyphicon-refresh" ng-show="stape1.loading"></span>
-                        </button>
-                    </div>
-                </div>
-            </form>
-        </div>
-    </div>
-    <div class="row" ng-show="stape == 2">
-        <div class="col-md-2 text-right h3">
-            Étape 2<br />
-            <small>Choix de la commande</small>
-        </div>
-        <div class="col-md-10">
-            <table class="table table-hover table-striped">
-                <thead>
-                    <tr>
-                        <th>Date</th>
-                        <th>Numéro de commande</th>
-                        <th class="text-center">Prévisualiser</th>
-                        <th class="text-center">Sélectionner</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr ng-repeat="order in stape2.orders">
-                        <td>{{ order.date | amParse:'DD/MM/YYYY' | amCalendar }}</td>
-                        <td>{{ order.id }}</td>
-                        <td class="text-center">
-                            <a href ng-click="stape2.preview(order)" ng-show="!order.loadingp">Prévisualiser</a>
-                            <span class="glyphicon-refresh-animate glyphicon glyphicon-refresh" ng-if="order.loadingp"></span>
-                        </td>
-                        <td class="text-center">
-                            <a href ng-click="stape2.select(order)" ng-show="!order.loadings">Sélectionner</a>
-                            <span class="glyphicon-refresh-animate glyphicon glyphicon-refresh" ng-if="order.loadings"></span>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
+                <button type="submit" class="btn btn-success" ng-class="input == '' && 'disabled' || ''">Valider</button>
+            </div>
+        </form>
     </div>
 </div>

--- a/app/components/admin/food/autoappro/ooshop.html
+++ b/app/components/admin/food/autoappro/ooshop.html
@@ -1,6 +1,9 @@
 <div class="col-sm-12 col-md-12 col-lg-12">
     <h3>Auto-Appro : Ooshop</h3>
     <div class="col-md-10">
+        <div class="well">
+            Rendez-vous sur www.ooshop.com, dans l’onglet <a href="http://www.ooshop.com/courses-en-ligne/WebForms/Utilisateur/MesCommandes.aspx">Mes commandes</a>, puis séléctionnez "Imprimer la facture" pour la commande voulue. Refusez l’impression, mais copiez la facture intégralement (avec ctrl-A ctrl-C par exemple), puis collez-la dans l’encadré suivant (ctrl-V).
+        </div>
         <form class="form-horizontal" ng-submit="validate(input)">
             <div class="form-group">
                 <label class="col-md-4 col-lg-2 control-label">Copiez votre facture Ooshop ici</label>


### PR DESCRIPTION
J’ai modifié l’interface pour l’auto appro Ooshop, qui n’était plus fonctionnelle depuis qu’Ooshop a modifié des trucs :
Il faut maintenant copier entièrement la facture au format html, et la coller sur Chocapix.
La facture peut s’obtenir dans la page "Mes commandes", en cliquant sur "Imprimer la facture". À partir de là, il suffit de copier l’intégralité de la page dans la boîte à texte sur Chocapix, et valider.