### PR TITLE
Modification de l’appro Ooshop pour suivre le nouveau site de juillet 2017 (factures pdf)

### DIFF
--- a/app/components/admin/food/autoappro/ooshop.html
+++ b/app/components/admin/food/autoappro/ooshop.html
@@ -3,7 +3,7 @@
     <h3>Auto-Appro : Ooshop</h3>
 	<div class="col-md-10">
         <div class="well">
-            Séléctionne la facture de l’appro (à télécharger sur la page <a href="https://www.ooshop.carrefour.com/orders">Mes dernières commandes</a>).
+            Séléctionne la facture de l’appro au format PDF (à télécharger sur la page <a href="https://www.ooshop.carrefour.com/orders">Mes dernières commandes</a>).
         </div>
         <form class="form-horizontal" ng-submit="validate()">
             <div class="form-group">
@@ -11,6 +11,6 @@
                 <button type="submit" class="btn btn-success" ng-class="parsing_receipt && 'disabled' || ''">Valider</button>
             </div>
         </form>
-        <p ng-show="parsing_receipt">Analyse du pdf en cours…</p>
+        <p ng-show="parsing_receipt">Analyse du PDF en cours…</p>
     </div>
 </div>

--- a/app/components/admin/food/autoappro/ooshop.html
+++ b/app/components/admin/food/autoappro/ooshop.html
@@ -1,17 +1,16 @@
+<script src="//mozilla.github.io/pdf.js/build/pdf.js"></script>
 <div class="col-sm-12 col-md-12 col-lg-12">
     <h3>Auto-Appro : Ooshop</h3>
-    <div class="col-md-10">
+	<div class="col-md-10">
         <div class="well">
-            Rendez-vous sur www.ooshop.com, dans l’onglet <a href="http://www.ooshop.com/courses-en-ligne/WebForms/Utilisateur/MesCommandes.aspx">Mes commandes</a>, puis séléctionnez "Imprimer la facture" pour la commande voulue. Refusez l’impression, mais copiez la facture intégralement (avec ctrl-A ctrl-C par exemple), puis collez-la dans l’encadré suivant (ctrl-V).
+            Séléctionne la facture de l’appro (à télécharger sur la page <a href="https://www.ooshop.carrefour.com/orders">Mes dernières commandes</a>).
         </div>
-        <form class="form-horizontal" ng-submit="validate(input)">
+        <form class="form-horizontal" ng-submit="validate()">
             <div class="form-group">
-                <label class="col-md-4 col-lg-2 control-label">Copiez votre facture Ooshop ici</label>
-                <div class="col-md-8 col-lg-10">
-                    <textarea name="Facture" class="form-control" ng-model="input" />
-                </div>
-                <button type="submit" class="btn btn-success" ng-class="input == '' && 'disabled' || ''">Valider</button>
+                <input required id="receipt_pdf" type="file" />
+                <button type="submit" class="btn btn-success" ng-class="parsing_receipt && 'disabled' || ''">Valider</button>
             </div>
         </form>
+        <p ng-show="parsing_receipt">Analyse du pdf en cours…</p>
     </div>
 </div>


### PR DESCRIPTION
Pour répondre à https://panix.binets.fr/T174

Il faut maintenant séléctionner l’appro au format pdf (que l’on peut télécharger sur Ooshop), et valider.
Je n’ai testé pour l’instant que sur la facture qui était donnée dans le thread PaniX.

Il y a trois points peut-être à revoir :
- J’ai inclus pdf.js (http://mozilla.github.io/pdf.js/build/pdf.js) au début de la page app/components/admin/food/autoappro/ooshop.html. Fallait-il l’inclure dans la page app/index.html comme tout les autres scripts ?
- Lorsque l’on appuie sur le bouton Valider, je désactive le bouton, et si le fichier n’a pas pu être lu (par exemple ce n’est pas un pdf), il devrait se réactiver (c’est la variable $scope.parsing_receipt qui s’en occupe). Seulement, chez moi ça met du temps avant de se réactiver, et je ne sais pas comment accélerer cela.
- Enfin, le design est pas ouf ^^'

Bref, je vais essayer de tester sur d’autres factures pour voir.

(Merci à PJ, Grégoire Deletang et Grégoire Thomazeau pour leur aide)